### PR TITLE
Add Brewfile and global CLAUDE.md support

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,18 @@
+# User-friendly command-line shell for UNIX-like operating systems
+brew "fish"
+# GitHub command-line tool
+brew "gh"
+# Distributed revision control system
+brew "git"
+# Tools and libraries to manipulate images in select formats
+brew "imagemagick"
+# Command-line interface for SQLite
+brew "sqlite"
+# Open-source, cross-platform JavaScript runtime environment
+brew "node"
+# Interpreted, interactive, object-oriented programming language
+brew "python@3.14"
+# Open-source code editor
+cask "visual-studio-code"
+vscode "anthropic.claude-code"
+vscode "google.geminicodeassist"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,27 +1,26 @@
-# Global Claude Code Instructions
+# CLAUDE.md (Global)
 
-This file contains personal instructions and preferences for Claude Code across all projects.
+## 🧠 Workflow Protocol
+1.  **Plan:** Start every task with a bulleted implementation plan.
+2.  **Review:** Pause for user approval.
+3.  **Branch:** Create a feature branch (`feature/description`) immediately after approval.
+4.  **Test:** Write/Update tests (TDD) before implementation.
+5.  **Verify:** Run tests locally and confirm success before PR.
+6.  **PR:** Generate a PR description with Summary, Verification Proof, and Rationale.
 
-## General Preferences
+## 🛠 Code Standards
+- **Style:** Match existing patterns. When in doubt, read local configuration files (e.g., `.eslintrc`, `pyproject.toml`).
+- **Commits:** Create atomic, small commits with semantic messages (e.g., `feat:`, `fix:`).
+- **Security:** Use environment variables for secrets. Validate inputs at system boundaries.
+- **Handling:** Fail gracefully with explicit error messages.
 
-- Keep responses concise and focused
-- Prefer simple solutions over complex ones
-- Always test changes before committing
+## 🤖 Interaction Style
+- **Concise:** Provide code and facts. Omit pleasantries and filler ("I hope this helps").
+- **Honest:** If you lack context, ask. If you cannot find a file, say so.
+- **Context:** Read `README.md` or `docs/` files if the prompt implies domain complexity.
 
-## Code Style
-
-- Use 2-space indentation
-- Prefer modern language features
-- Write self-documenting code with minimal comments
-
-## Workflow
-
-- Create feature branches for changes
-- Write clear commit messages
-- Create PRs for review before merging
-
-## Tools & Environment
-
-- Primary editor: VSCode
-- Shell: Fish
-- Platform: macOS (Apple Silicon)
+## ⚡️ Standard Commands
+(Update these per project if necessary)
+- **Test:** `npm test` or `pytest`
+- **Lint:** `npm run lint` or `flake8`
+- **Build:** `npm run build`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,27 @@
+# Global Claude Code Instructions
+
+This file contains personal instructions and preferences for Claude Code across all projects.
+
+## General Preferences
+
+- Keep responses concise and focused
+- Prefer simple solutions over complex ones
+- Always test changes before committing
+
+## Code Style
+
+- Use 2-space indentation
+- Prefer modern language features
+- Write self-documenting code with minimal comments
+
+## Workflow
+
+- Create feature branches for changes
+- Write clear commit messages
+- Create PRs for review before merging
+
+## Tools & Environment
+
+- Primary editor: VSCode
+- Shell: Fish
+- Platform: macOS (Apple Silicon)

--- a/install.fish
+++ b/install.fish
@@ -26,10 +26,14 @@ for file in $DOTFILES/*
     end
 end
 
-# Claude Code global instructions
+# AI assistant global instructions
 echo CLAUDE.md
 mkdir -p ~/.claude
 ln -f -s $DOTFILES/CLAUDE.md ~/.claude/CLAUDE.md
+
+echo "GEMINI.md (symlink to CLAUDE.md)"
+mkdir -p ~/.gemini
+ln -f -s $DOTFILES/CLAUDE.md ~/.gemini/GEMINI.md
 
 echo
 echo "=== Fish Shell ==="

--- a/install.fish
+++ b/install.fish
@@ -3,11 +3,21 @@
 # Ensure we are in the directory of the script to get absolute paths correct
 cd (dirname (status -f))
 set DOTFILES (pwd)
-set exclude_us README.md LICENSE.md install.fish test_config.fish fish .git .DS_Store .gitignore
+set exclude_us README.md LICENSE.md install.fish test_config.fish fish .git .DS_Store .gitignore Brewfile CLAUDE.md
 
-echo "Installing all dotfiles into $USER's home directory..."
+echo "Installing dotfiles for $USER..."
 echo "(Existing files will be overwritten)"
 echo
+
+# Brewfile first - installs Fish and other dependencies
+echo "=== Homebrew Packages ==="
+echo Brewfile
+ln -f -s $DOTFILES/Brewfile ~/.Brewfile
+echo "Running brew bundle to install packages..."
+brew bundle install --global
+echo
+
+echo "=== Dotfiles ==="
 for file in $DOTFILES/*
     set filename (basename $file)
     if not contains $filename $exclude_us
@@ -16,6 +26,13 @@ for file in $DOTFILES/*
     end
 end
 
+# Claude Code global instructions
+echo CLAUDE.md
+mkdir -p ~/.claude
+ln -f -s $DOTFILES/CLAUDE.md ~/.claude/CLAUDE.md
+
+echo
+echo "=== Fish Shell ==="
 echo fish/config.fish
 ln -f -s $DOTFILES/fish/config.fish ~/.config/fish/config.fish
 echo fish/functions
@@ -30,7 +47,7 @@ for func in $DOTFILES/fish/functions/*.fish
 end
 
 echo
-echo "Setting up Fish as default shell..."
+echo "=== Default Shell ==="
 
 # Get the path to Fish
 set FISH_PATH (which fish)
@@ -54,6 +71,7 @@ else
 end
 
 echo
+echo "=== Complete ==="
 echo "✓ Installation complete!"
 echo
 echo "Reloading Fish configuration..."


### PR DESCRIPTION
## Summary

Adds version-controlled Homebrew package management and Claude Code global instructions to the dotfiles repository.

## New Files

### [Brewfile](Brewfile)
Captures all currently installed Homebrew packages:
- **CLI tools**: fish, gh, git, imagemagick, sqlite, node, python
- **Applications**: Visual Studio Code
- **VSCode extensions**: Claude Code, Gemini Code Assist

### [CLAUDE.md](CLAUDE.md)
Global Claude Code instructions template with:
- General preferences
- Code style guidelines
- Workflow conventions
- Tools & environment info

## Changes to [install.fish](install.fish)

**Reorganized installation order:**
1. `brew bundle install --global` - Install all packages first (including Fish)
2. Symlink dotfiles
3. Symlink CLAUDE.md to `~/.claude/CLAUDE.md`
4. Set up Fish shell configuration
5. Configure Fish as default shell

**Improved output:**
- Added section headers (=== Homebrew Packages ===, === Dotfiles ===, etc.)
- Better visual organization of installation progress

## Usage

On a new machine:
```bash
# First install Homebrew and Fish
/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
brew install fish

# Then run the dotfiles installer
./install.fish
```

## Test Plan

- [ ] Verify Brewfile symlinks to ~/.Brewfile
- [ ] Verify CLAUDE.md symlinks to ~/.claude/CLAUDE.md  
- [ ] Run `brew bundle check --global` to verify packages
- [ ] Confirm Claude Code picks up the global CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)